### PR TITLE
init not saving access_token correctly

### DIFF
--- a/ctfcli/__main__.py
+++ b/ctfcli/__main__.py
@@ -33,7 +33,7 @@ class CTFCLI(object):
         os.mkdir(".ctf")
 
         config = configparser.ConfigParser()
-        config["config"] = {"url": ctf_url, "access_token": ctf_url}
+        config["config"] = {"url": ctf_url, "access_token": ctf_token}
         config["challenges"] = {}
 
         with open(".ctf/config", "a+") as f:


### PR DESCRIPTION
I noticed that when you ctf init, we are saving the wrong param