### PR TITLE
Add changes to support API improvements in CTFd v2.5.0

### DIFF
--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -16,7 +16,7 @@ def load_challenge(path):
 
 def load_installed_challenges():
     s = generate_session()
-    return s.get("/api/v1/challenges", json=True).json()["data"]
+    return s.get("/api/v1/challenges?view=admin", json=True).json()["data"]
 
 
 def sync_challenge(challenge):


### PR DESCRIPTION
* Load all challenges from CTFd API by calling `/api/v1/challenges?view=admin`. This should fallback on older CTFd instances. 