### PR TITLE
Mark 0.0.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 # Changelog
 
+
+0.0.4 / 2020-06-07
+==================
+### Added
+- `ctfcli` will now load all challenges regardless of visibility when using an
+admin token. Requires CTFd v2.5.0
+
+
 0.0.3 / 2020-04-09
 ==================
 ### Fixed

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __name__ = "ctfcli"


### PR DESCRIPTION
0.0.4 / 2020-06-07
==================
### Added
- `ctfcli` will now load all challenges regardless of visibility when using an
admin token. Requires CTFd v2.5.0