### PR TITLE
feat: Challenge state accepted in spec

### DIFF
--- a/ctfcli/spec/challenge-example.yml
+++ b/ctfcli/spec/challenge-example.yml
@@ -66,6 +66,10 @@ requirements:
     - "Are you alive"
     - 1
 
+# The state of the challenge.
+# This is visible by default. It takes two values: hidden, visible.
+state: hidden
+
 # Specifies what version of the challenge specification was used.
 # Subject to change until ctfcli v1.0.0
 version: "0.1"

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -141,7 +141,7 @@ def sync_challenge(challenge):
 
     # Unhide challenge depending upon the value of "state" in spec
     data = {"state": "visible"}
-    if (challenge.get("state")):
+    if challenge.get("state"):
         if challenge["state"] in ["hidden", "visible"]:
             data["state"] = challenge["state"]
 
@@ -206,7 +206,7 @@ def create_challenge(challenge):
                 }
 
             r = s.post(f"/api/v1/hints", json=data)
-            r.raise_for_status()
+            r.raise_for_status()        
 
     # Add requirements
     if challenge.get("requirements"):
@@ -222,6 +222,15 @@ def create_challenge(challenge):
 
         required_challenges = list(set(required_challenges))
         data = {"requirements": {"prerequisites": required_challenges}}
+        r = s.patch(f"/api/v1/challenges/{challenge_id}", json=data)
+        r.raise_for_status()
+
+    # Set challenge state
+    if challenge.get("state"):
+        data = {"state": "visible"}
+        if challenge["state"] in ["hidden", "visible"]:
+            data["state"] = challenge["state"]
+
         r = s.patch(f"/api/v1/challenges/{challenge_id}", json=data)
         r.raise_for_status()
 

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -227,7 +227,7 @@ def create_challenge(challenge):
 
     # Set challenge state
     if challenge.get("state"):
-        data = {"state": "visible"}
+        data = {"state": "hidden"}
         if challenge["state"] in ["hidden", "visible"]:
             data["state"] = challenge["state"]
 

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -139,8 +139,12 @@ def sync_challenge(challenge):
         r = s.patch(f"/api/v1/challenges/{challenge_id}", json=data)
         r.raise_for_status()
 
-    # Unhide challenge
+    # Unhide challenge depending upon the value of "state" in spec
     data = {"state": "visible"}
+    if (challenge.get("state")):
+        if challenge["state"] in ["hidden", "visible"]:
+            data["state"] = challenge["state"]
+
     r = s.patch(f"/api/v1/challenges/{challenge_id}", json=data)
     r.raise_for_status()
 

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -140,7 +140,7 @@ def sync_challenge(challenge):
         r.raise_for_status()
 
     # Unhide challenge depending upon the value of "state" in spec
-    data = {"state": "visible"}
+    data = {"state": "hidden"}
     if challenge.get("state"):
         if challenge["state"] in ["hidden", "visible"]:
             data["state"] = challenge["state"]

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -206,7 +206,7 @@ def create_challenge(challenge):
                 }
 
             r = s.post(f"/api/v1/hints", json=data)
-            r.raise_for_status()        
+            r.raise_for_status()
 
     # Add requirements
     if challenge.get("requirements"):


### PR DESCRIPTION
- The spec now accepts `state` in the `challenge.yml` file.
- The `state` can be `hidden` or `visible`.
- It is `visible` by default, so that it does not break the current workflow.
- Added `state` to `challenge-example.yml`.

Closes #11 
