### PR TITLE
Added support for relative files in `challenge install` and `sync`

### DIFF
--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -104,7 +104,7 @@ class Challenge(object):
                     return
 
         click.secho(f'Installing {challenge["name"]}', fg="yellow")
-        create_challenge(challenge=challenge)
+        create_challenge(challenge=challenge, path=path)
         click.secho(f"Success!", fg="green")
 
     def sync(self, challenge=None):
@@ -131,7 +131,7 @@ class Challenge(object):
             )
 
         click.secho(f'Syncing {challenge["name"]}', fg="yellow")
-        sync_challenge(challenge=challenge)
+        sync_challenge(challenge=challenge, path=path)
         click.secho(f"Success!", fg="green")
 
     def finalize(self, challenge=None):

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -1,6 +1,7 @@
 import yaml
 
 import click
+import os
 
 from .config import generate_session
 
@@ -19,7 +20,7 @@ def load_installed_challenges():
     return s.get("/api/v1/challenges?view=admin", json=True).json()["data"]
 
 
-def sync_challenge(challenge):
+def sync_challenge(challenge, path = None):
     data = {
         "name": challenge["name"],
         "category": challenge["category"],
@@ -92,6 +93,15 @@ def sync_challenge(challenge):
     if challenge.get("files"):
         files = []
         for f in challenge["files"]:
+
+            if not os.path.exists(f):
+                if path is not None:
+                    rel_path = os.path.join(os.path.dirname(path), f)
+                    if not os.path.exists(rel_path):
+                        click.secho(f"File {f} was not found", fg="red")
+                        return
+                    f = rel_path
+
             files.append(("file", open(f, "rb")))
 
         data = {"challenge": challenge_id, "type": "challenge"}
@@ -149,7 +159,7 @@ def sync_challenge(challenge):
     r.raise_for_status()
 
 
-def create_challenge(challenge):
+def create_challenge(challenge, path=None):
     data = {
         "name": challenge["name"],
         "category": challenge["category"],
@@ -186,6 +196,15 @@ def create_challenge(challenge):
     if challenge.get("files"):
         files = []
         for f in challenge["files"]:
+
+            if not os.path.exists(f):
+                if path is not None:
+                    rel_path = os.path.join(os.path.dirname(path), f)
+                    if not os.path.exists(rel_path):
+                        click.secho(f"File {f} was not found", fg="red")
+                        return
+                    f = rel_path
+
             files.append(("file", open(f, "rb")))
 
         data = {"challenge": challenge_id, "type": "challenge"}

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -154,6 +154,8 @@ def sync_challenge(challenge, path = None):
     if challenge.get("state"):
         if challenge["state"] in ["hidden", "visible"]:
             data["state"] = challenge["state"]
+    else:
+        data["state"] = "visible"
 
     r = s.patch(f"/api/v1/challenges/{challenge_id}", json=data)
     r.raise_for_status()


### PR DESCRIPTION
`ctfcli` would error when it could not find a file outlined in the `challenge.yml` file if it were relative to the `challenge.yml` file path location, while the tool was invoked in a different path location. I've just included the `path` variable in the `create_challenge` and `sync_challenge` functions so it can detect whether or not it means a file in the current working directoy, or where the challenge folder is specified.