### PR TITLE
Mark 0.0.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 # Changelog
 
 
+0.0.6 / 2020-10-07
+==================
+### Fixed
+- Properly default the challenge state to visible during sync
+
+
 0.0.5 / 2020-10-07
 ==================
 ### Added

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 __name__ = "ctfcli"


### PR DESCRIPTION
0.0.6 / 2020-10-07
==================
### Fixed
- Properly default the challenge state to visible during sync