### PR TITLE
Add 'ctf challenge deploy', run isort, fix issue with setup.py

### DIFF
--- a/ctfcli/__main__.py
+++ b/ctfcli/__main__.py
@@ -6,13 +6,12 @@ import sys
 from pathlib import Path
 
 import click
+import fire
 
 from ctfcli.cli.challenges import Challenge
 from ctfcli.cli.config import Config
 from ctfcli.cli.plugins import Plugins
 from ctfcli.utils.plugins import get_plugin_dir
-
-import fire
 
 
 class CTFCLI(object):

--- a/ctfcli/cli/config.py
+++ b/ctfcli/cli/config.py
@@ -2,10 +2,10 @@ import os
 import subprocess
 
 import click
-
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
 from pygments.lexers import IniLexer, JsonLexer
+
 from ctfcli.utils.config import get_config_path, preview_config
 
 

--- a/ctfcli/spec/challenge-example.yml
+++ b/ctfcli/spec/challenge-example.yml
@@ -15,6 +15,12 @@ type: standard
 # If you have an imaged hosted on Docker set to the image url (e.g. python/3.8:latest, registry.gitlab.com/python/3.8:latest)
 # Follow Docker best practices and assign a tag
 image: null
+# Specify a host to deploy the challenge onto.
+# The currently supported URI schemes are ssh:// and registry://
+# ssh is an ssh URI where the above image will be copied to and deployed (e.g. ssh://root@123.123.123.123)
+# registry is a Docker registry tag (e.g registry://registry.example.com/test/image)
+# host can also be specified during the deploy process: `ctf challenge deploy challenge --host=ssh://root@123.123.123.123`
+host: null
 
 # Optional settings
 # Can be removed if unused

--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 
-import yaml
-
 import click
+import yaml
 
 from .config import generate_session
 

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -2,9 +2,9 @@ import configparser
 import json
 import os
 
-from .api import APISession
-
 from ctfcli import __file__ as base_path
+
+from .api import APISession
 
 
 def get_base_path():

--- a/ctfcli/utils/deploy.py
+++ b/ctfcli/utils/deploy.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+from ctfcli.utils.images import build_image, export_image, get_exposed_ports
+
+
+def ssh(challenge, host):
+    # Build image
+    image_name = build_image(challenge=challenge)
+    print(f"Built {image_name}")
+
+    # Export image to a file
+    image_path = export_image(challenge=challenge)
+    print(f"Exported {image_name} to {image_path}")
+    filename = Path(image_path).name
+
+    # Transfer file to SSH host
+    print(f"Transferring {image_path} to {host}")
+    host = urlparse(host)
+    folder = host.path or "/tmp"
+    target_file = f"{folder}/{filename}"
+    exposed_port = get_exposed_ports(challenge=challenge)
+    domain = host.netloc[host.netloc.find("@") + 1 :]
+    subprocess.run(["scp", image_path, f"{host.netloc}:{target_file}"])
+    subprocess.run(
+        ["ssh", host.netloc, f"docker load -i {target_file} && rm {target_file}"]
+    )
+    subprocess.run(
+        [
+            "ssh",
+            host.netloc,
+            f"docker run -d -p{exposed_port}:{exposed_port} {image_name}",
+        ]
+    )
+
+    # Clean up files
+    os.remove(image_path)
+    print(f"Cleaned up {image_path}")
+
+    return True, domain, exposed_port
+
+
+def registry(challenge, host):
+    # Build image
+    image_name = build_image(challenge=challenge)
+    print(f"Built {image_name}")
+    url = urlparse(host)
+    tag = f"{url.netloc}{url.path}"
+    subprocess.call(["docker", "tag", image_name, tag])
+    subprocess.call(["docker", "push", tag])
+
+
+DEPLOY_HANDLERS = {"ssh": ssh, "registry": registry}

--- a/ctfcli/utils/images.py
+++ b/ctfcli/utils/images.py
@@ -1,0 +1,47 @@
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def sanitize_name(name):
+    """
+    Function to sanitize names to docker safe image names
+    TODO: Good enough but probably needs to be more conformant with docker
+    """
+    return name.lower().replace(" ", "-")
+
+
+def build_image(challenge):
+    name = sanitize_name(challenge["name"])
+    path = Path(challenge.file_path).parent.absolute()
+    print(f"Building {name} from {path}")
+    subprocess.call(["docker", "build", "-t", name, "."], cwd=path)
+    return name
+
+
+def export_image(challenge):
+    name = sanitize_name(challenge["name"])
+    temp = tempfile.NamedTemporaryFile(delete=False, suffix=f"_{name}.docker.tar")
+    subprocess.call(["docker", "save", "--output", temp.name, name])
+    return temp.name
+
+
+def get_exposed_ports(challenge):
+    image_name = sanitize_name(challenge["name"])
+    output = subprocess.check_output(
+        ["docker", "inspect", "--format={{json .Config.ExposedPorts }}", image_name,]
+    )
+    output = json.loads(output)
+    if output:
+        ports = list(output.keys())
+        if ports:
+            # Split '2323/tcp'
+            port = ports[0]
+            port = port.split("/")
+            port = port[0]
+            return port
+        else:
+            return None
+    else:
+        return None

--- a/ctfcli/utils/plugins.py
+++ b/ctfcli/utils/plugins.py
@@ -1,5 +1,6 @@
-import appdirs
 import os
+
+import appdirs
 
 from ctfcli import __name__ as pkg_name
 

--- a/ctfcli/utils/spec.py
+++ b/ctfcli/utils/spec.py
@@ -1,9 +1,8 @@
-import yaml
-
+import getpass
 from collections import namedtuple
 from pathlib import Path
-import getpass
 
+import yaml
 
 Prompt = namedtuple("Prompt", ["text", "type", "default", "required", "multiple"])
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import re
 
 try:
@@ -6,7 +7,6 @@ try:
 except ImportError:
     from distutils.core import setup, find_packages
 
-import os
 
 with open("ctfcli/__init__.py") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
@@ -31,6 +31,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords=["ctf"],
     classifiers=[],
+    zip_safe=False,
     install_requires=[
         "cookiecutter==1.6.0",
         "click==7.0",


### PR DESCRIPTION
* Add `ctf challenge deploy [challenge]` command
  * Support for `ssh://` and `registry://` deploy targets
* Run isort
* Fix some issues where setup.py apparently didn't work