### PR TITLE
fix: allow ctfd in different application root

### DIFF
--- a/ctfcli/utils/api.py
+++ b/ctfcli/utils/api.py
@@ -9,5 +9,5 @@ class APISession(Session):
         self.prefix_url = prefix_url
 
     def request(self, method, url, *args, **kwargs):
-        url = urljoin(self.prefix_url, url)
+        url = urljoin(self.prefix_url, url.lstrip("/"))
         return super(APISession, self).request(method, url, *args, **kwargs)

--- a/ctfcli/utils/api.py
+++ b/ctfcli/utils/api.py
@@ -6,8 +6,12 @@ from requests import Session
 class APISession(Session):
     def __init__(self, prefix_url=None, *args, **kwargs):
         super(APISession, self).__init__(*args, **kwargs)
-        self.prefix_url = prefix_url
+        # Strip out ending slashes and append a singular one so we generate
+        # clean base URLs for both main deployments and subdir deployments
+        self.prefix_url = prefix_url.rstrip("/") + "/"
 
     def request(self, method, url, *args, **kwargs):
+        # Strip out the preceding / so that urljoin creates the right url
+        # considering the appended / on the prefix_url
         url = urljoin(self.prefix_url, url.lstrip("/"))
         return super(APISession, self).request(method, url, *args, **kwargs)

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -64,8 +64,7 @@ def preview_config(as_string=False):
 def generate_session():
     config = load_config()
     url = config["config"]["url"]
-    url = url.rstrip("/") + "/"
     access_token = config["config"]["access_token"]
-    s = APISession(url)
+    s = APISession(prefix_url=url)
     s.headers.update({"Authorization": f"Token {access_token}"})
     return s

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -64,7 +64,7 @@ def preview_config(as_string=False):
 def generate_session():
     config = load_config()
     url = config["config"]["url"]
-    url = url.strip("/")
+    url = url.rstrip("/") + "/"
     access_token = config["config"]["access_token"]
     s = APISession(url)
     s.headers.update({"Authorization": f"Token {access_token}"})


### PR DESCRIPTION
If CTFd has and application root other than "/", for example http://ctf.com/platform, ctfcli crashes because urljoin doesn't concatenate strings well.
Urljoin needs a base url with a "/" at the end and an url without "/" at the beginning as a second argument.