### PR TITLE
Add more lint checks

### DIFF
--- a/ctfcli/utils/challenge.py
+++ b/ctfcli/utils/challenge.py
@@ -287,11 +287,42 @@ def lint_challenge(path):
     required_fields = ["name", "author", "category", "description", "value"]
     errors = []
     for field in required_fields:
-        if challenge.get(field) is None:
-            errors.append(field)
+        if field == "value" and challenge.get("type") == "dynamic":
+            pass
+        else:
+            if challenge.get(field) is None:
+                errors.append(field)
 
     if len(errors) > 0:
         print("Missing fields: ", ", ".join(errors))
+        exit(1)
+
+    # Check that the image field and Dockerfile match
+    if (Path(path).parent / "Dockerfile").is_file() and challenge.get("image") != ".":
+        print("Dockerfile exists but image field does not point to it")
+        exit(1)
+
+    # Check that Dockerfile exists and is EXPOSE'ing a port
+    if challenge.get("image") == ".":
+        try:
+            dockerfile = (Path(path).parent / "Dockerfile").open().read()
+        except FileNotFoundError:
+            print("Dockerfile specified in 'image' field but no Dockerfile found")
+            exit(1)
+
+        if "EXPOSE" not in dockerfile:
+            print("Dockerfile missing EXPOSE")
+            exit(1)
+
+    # Check that all files exists
+    files = challenge.get("files")
+    errored = False
+    for f in files:
+        fpath = Path(path).parent / f
+        if fpath.is_file() is False:
+            print(f"File {f} specified but not found at {fpath.absolute()}")
+            errored = True
+    if errored:
         exit(1)
 
     exit(0)


### PR DESCRIPTION
* Lint that Dockerfiles EXPOSE a port
* Lint that if your challenge spec doesn't provide an image that you don't provide a Dockerfile
* Lint that all files being searched for are provided
* Closes #40 