### PR TITLE
Mark 0.0.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@
 ==================
 ### Added
 - Added an `extra` field in challenge specification to support different CTFd challenge types
-    - This adds support for dynamic value challenges in CTFd > 3.3.0 (Must have commit df27d0e7a9e336b86165d41920aa176db4ff0e06).
+    - This adds support for dynamic value challenges in CTFd > 3.3.0 (Must have commit [df27d0e7a9e336b86165d41920aa176db4ff0e06](https://github.com/CTFd/CTFd/commit/df27d0e7a9e336b86165d41920aa176db4ff0e06)).
 - Improved `ctf challenge lint` to catch some common mistakes in a challenge
 - Added an `--ignore` flag to `ctf challenge install` and `ctf challenge sync` to disable installation of certain challenge properties (e.g. flags, tags, hints, etc).
     - Usage: `ctf challenge install challenge.yml --ignore=flags,tags`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 # Changelog
 
 
-UNRELEASED
+0.0.8 / 2021-06-21
 ==================
 ### Added
 - Added an `extra` field in challenge specification to support different CTFd challenge types
@@ -12,6 +12,7 @@ UNRELEASED
     - Usage: `ctf challenge install --ignore=flags,tags`
     - Usage: `ctf challenge sync challenge.yml --ignore=flags,tags`
     - Usage: `ctf challenge sync --ignore=flags,tags`
+- Automatic releases from Github to PyPI
 
 ### Fixed
 - Fix web challenge template for serve.sh

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 __name__ = "ctfcli"


### PR DESCRIPTION
0.0.8 / 2021-06-21
==================
### Added
- Added an `extra` field in challenge specification to support different CTFd challenge types
    - This adds support for dynamic value challenges in CTFd > 3.3.0 (Must have commit [df27d0e7a9e336b86165d41920aa176db4ff0e06](https://github.com/CTFd/CTFd/commit/df27d0e7a9e336b86165d41920aa176db4ff0e06)).
- Improved `ctf challenge lint` to catch some common mistakes in a challenge
- Added an `--ignore` flag to `ctf challenge install` and `ctf challenge sync` to disable installation of certain challenge properties (e.g. flags, tags, hints, etc).
    - Usage: `ctf challenge install challenge.yml --ignore=flags,tags`
    - Usage: `ctf challenge install --ignore=flags,tags`
    - Usage: `ctf challenge sync challenge.yml --ignore=flags,tags`
    - Usage: `ctf challenge sync --ignore=flags,tags`
- Automatic releases from Github to PyPI

### Fixed
- Fix web challenge template for serve.sh
- Changed all Alpine images in Dockerfiles to use Debian
- Add examples or more complicated flag creation examples to challenge specification