### PR TITLE
Refactor the ctf challenge add interface to create the challenge repo using git subtree

### DIFF
--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -97,9 +97,8 @@ class Challenge(object):
             if url.endswith(".git"):
                 if challenge is not None and folder != challenge:
                     continue
-                click.echo(f"Cloning {url} to {folder}")
-                subprocess.call(["git", "clone", "--depth", "1", url, folder])
-                shutil.rmtree(str(Path(folder) / ".git"))
+                click.echo(f"Adding subtree {url} to {folder}")
+                subprocess.call(["git", "subtree", "add", "--prefix", folder, url, "master", "--squash"])
             else:
                 click.echo(f"Skipping {url} - {folder}")
 
@@ -186,22 +185,11 @@ class Challenge(object):
             if challenge and challenge != folder:
                 continue
             if url.endswith(".git"):
-                click.echo(f"Cloning {url} to {folder}")
-                subprocess.call(["git", "init"], cwd=folder)
-                subprocess.call(["git", "remote", "add", "origin", url], cwd=folder)
-                subprocess.call(["git", "add", "-A"], cwd=folder)
-                subprocess.call(
-                    ["git", "commit", "-m", "Persist local changes (ctfcli)"],
-                    cwd=folder,
-                )
-                subprocess.call(
-                    ["git", "pull", "--allow-unrelated-histories", "origin", "master"],
-                    cwd=folder,
-                )
+                click.echo(f"Pulling latest {url} to {folder}")
+                subprocess.call(["git", "subtree", "pull", "--prefix", folder, url, "master", "--squash"])
                 subprocess.call(["git", "mergetool"], cwd=folder)
                 subprocess.call(["git", "clean", "-f"], cwd=folder)
                 subprocess.call(["git", "commit", "--no-edit"], cwd=folder)
-                shutil.rmtree(str(Path(folder) / ".git"))
             else:
                 click.echo(f"Skipping {url} - {folder}")
 

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -217,7 +217,7 @@ class Challenge(object):
                     ],
                     cwd=get_project_path(),
                 )
-                subprocess.call(["git", "mergetool", "--prompt"], cwd=folder)
+                subprocess.call(["git", "mergetool"], cwd=folder)
                 subprocess.call(["git", "clean", "-f"], cwd=folder)
                 subprocess.call(["git", "commit", "--no-edit"], cwd=folder)
             else:

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -1,5 +1,4 @@
 import os
-import re
 import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
@@ -25,6 +24,7 @@ from ctfcli.utils.deploy import DEPLOY_HANDLERS
 from ctfcli.utils.spec import CHALLENGE_SPEC_DOCS, blank_challenge_spec
 from ctfcli.utils.templates import get_template_dir
 from ctfcli.utils.git import get_git_repo_head_branch
+
 
 class Challenge(object):
     def new(self, type="blank"):
@@ -68,7 +68,19 @@ class Challenge(object):
             config["challenges"][str(challenge_path)] = repo
 
             head_branch = get_git_repo_head_branch(repo)
-            subprocess.call(["git", "subtree", "add", "--prefix", challenge_path, repo, head_branch, "--squash"], cwd=get_project_path())
+            subprocess.call(
+                [
+                    "git",
+                    "subtree",
+                    "add",
+                    "--prefix",
+                    challenge_path,
+                    repo,
+                    head_branch,
+                    "--squash",
+                ],
+                cwd=get_project_path(),
+            )
             with open(get_config_path(), "w+") as f:
                 config.write(f)
 
@@ -91,7 +103,19 @@ class Challenge(object):
                     continue
                 click.echo(f"Adding git repo {url} to {folder} as subtree")
                 head_branch = get_git_repo_head_branch(url)
-                subprocess.call(["git", "subtree", "add", "--prefix", folder, url, head_branch, "--squash"], cwd=get_project_path())
+                subprocess.call(
+                    [
+                        "git",
+                        "subtree",
+                        "add",
+                        "--prefix",
+                        folder,
+                        url,
+                        head_branch,
+                        "--squash",
+                    ],
+                    cwd=get_project_path(),
+                )
             else:
                 click.echo(f"Skipping {url} - {folder}")
 
@@ -180,7 +204,19 @@ class Challenge(object):
             if url.endswith(".git"):
                 click.echo(f"Pulling latest {url} to {folder}")
                 head_branch = get_git_repo_head_branch(url)
-                subprocess.call(["git", "subtree", "pull", "--prefix", folder, url, head_branch, "--squash"], cwd=get_project_path())
+                subprocess.call(
+                    [
+                        "git",
+                        "subtree",
+                        "pull",
+                        "--prefix",
+                        folder,
+                        url,
+                        head_branch,
+                        "--squash",
+                    ],
+                    cwd=get_project_path(),
+                )
                 subprocess.call(["git", "mergetool", "--prompt"], cwd=folder)
                 subprocess.call(["git", "clean", "-f"], cwd=folder)
                 subprocess.call(["git", "commit", "--no-edit"], cwd=folder)
@@ -301,6 +337,11 @@ class Challenge(object):
         try:
             url = challenges[challenge]
             head_branch = get_git_repo_head_branch(url)
-            subprocess.call(["git", "subtree", "push", "--prefix", challenge, url, head_branch], cwd=get_project_path())
+            subprocess.call(
+                ["git", "subtree", "push", "--prefix", challenge, url, head_branch],
+                cwd=get_project_path(),
+            )
         except KeyError:
-            click.echo("Couldn't process that challenge path. Please check that the challenge is added to .ctf/config and that your path matches.")
+            click.echo(
+                "Couldn't process that challenge path. Please check that the challenge is added to .ctf/config and that your path matches."
+            )

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -58,7 +58,7 @@ class Challenge(object):
             # Get relative path from project root to current directory
             challenge_path = Path(os.path.relpath(os.getcwd(), get_project_path()))
 
-            # Get new directory that will exist after clone
+            # Get new directory that will add the git subtree
             base_repo_path = Path(os.path.basename(repo).rsplit(".", maxsplit=1)[0])
 
             # Join targets
@@ -70,8 +70,10 @@ class Challenge(object):
             with open(get_config_path(), "w+") as f:
                 config.write(f)
 
-            subprocess.call(["git", "clone", "--depth", "1", repo])
-            shutil.rmtree(str(base_repo_path / ".git"))
+            # Setup remote to easily push and pull git subtree
+            subprocess.call(["git", "remote", "add", base_repo_path, repo])
+            print(f"Added git remote {base_repo_path}")
+            subprocess.call(["git", "subtree", "add", "--prefix", base_repo_path, base_repo_path, "master", "--squash"])
         elif Path(repo).exists():
             config["challenges"][repo] = repo
             with open(get_config_path(), "w+") as f:

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -71,13 +71,14 @@ class Challenge(object):
 
             config["challenges"][str(challenge_path)] = repo
 
-            with open(get_config_path(), "w+") as f:
-                config.write(f)
-
-            # Setup remote to easily push and pull git subtree
+            # Setup remote for a user to easily push and pull git subtree
             subprocess.call(["git", "remote", "add", base_repo_path, repo])
             print(f"Added git remote {base_repo_path}")
             subprocess.call(["git", "subtree", "add", "--prefix", challenge_path, base_repo_path, "master", "--squash"])
+
+            with open(get_config_path(), "w+") as f:
+                config.write(f)
+
         elif Path(repo).exists():
             config["challenges"][repo] = repo
             with open(get_config_path(), "w+") as f:

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -293,3 +293,20 @@ class Challenge(object):
             click.secho(
                 f"An error occured during deployment", fg="red",
             )
+
+    def push(self, challenge=None):
+        config = load_config()
+        challenges = dict(config["challenges"])
+        if challenge is None:
+            # Get relative path from project root to current directory
+            challenge_path = Path(os.path.relpath(os.getcwd(), get_project_path()))
+            challenge = str(challenge_path)
+
+        try:
+            url = challenges[challenge]
+            # Get default branch for the repo
+            git_remote = subprocess.check_output(["git", "remote", "show", url])
+            default_branch = re.findall('(?<=HEAD branch: )\w*', str(git_remote))[0]
+            subprocess.call(["git", "subtree", "push", "--prefix", challenge, url, default_branch], cwd=get_project_path())
+        except KeyError:
+            click.echo("Couldn't process that challenge path. Please check that the challenge is added to .ctf/config and that your path matches.")

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -51,7 +51,7 @@ class Challenge(object):
 
         Templates().list()
 
-    def add(self, repo):
+    def add(self, repo, category=None):
         config = load_config()
 
         if repo.endswith(".git"):
@@ -61,8 +61,12 @@ class Challenge(object):
             # Get new directory that will add the git subtree
             base_repo_path = Path(os.path.basename(repo).rsplit(".", maxsplit=1)[0])
 
-            # Join targets
-            challenge_path = challenge_path / base_repo_path
+            if category:
+                category_path = Path(category)
+                # Join targets
+                challenge_path = challenge_path / category_path / base_repo_path
+            else:
+                challenge_path = challenge_path / base_repo_path
             print(challenge_path)
 
             config["challenges"][str(challenge_path)] = repo
@@ -73,7 +77,7 @@ class Challenge(object):
             # Setup remote to easily push and pull git subtree
             subprocess.call(["git", "remote", "add", base_repo_path, repo])
             print(f"Added git remote {base_repo_path}")
-            subprocess.call(["git", "subtree", "add", "--prefix", base_repo_path, base_repo_path, "master", "--squash"])
+            subprocess.call(["git", "subtree", "add", "--prefix", challenge_path, base_repo_path, "master", "--squash"])
         elif Path(repo).exists():
             config["challenges"][repo] = repo
             with open(get_config_path(), "w+") as f:

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -68,10 +68,8 @@ class Challenge(object):
             config["challenges"][str(challenge_path)] = repo
 
             # Setup remote for a user to easily push and pull git subtree
-            subprocess.call(["git", "remote", "add", base_repo_path, repo], cwd=get_project_path())
             default_branch = subprocess.call("git", "remote", "show", repo, "|", "sed", "-n", "'/Fetch URL/s/.*: //p'")
             subprocess.call(["git", "subtree", "add", "--prefix", challenge_path, repo, default_branch, "--squash"], cwd=get_project_path())
-
             with open(get_config_path(), "w+") as f:
                 config.write(f)
 

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -61,6 +61,7 @@ class Challenge(object):
             # Get new directory that will add the git subtree
             base_repo_path = Path(os.path.basename(repo).rsplit(".", maxsplit=1)[0])
 
+            # Set the challenge path's category directory
             if category:
                 category_path = Path(category)
                 # Join targets

--- a/ctfcli/utils/git.py
+++ b/ctfcli/utils/git.py
@@ -1,0 +1,10 @@
+import subprocess
+
+def get_git_repo_head_branch(repo):
+    """
+    A helper method to get the reference of the HEAD branch of a git remote repo.
+    https://stackoverflow.com/a/41925348
+    """
+    out = subprocess.check_output(["git", "ls-remote", "--symref", repo, "HEAD"]).decode()
+    head_branch = out.split()[1]
+    return head_branch

--- a/ctfcli/utils/git.py
+++ b/ctfcli/utils/git.py
@@ -1,10 +1,13 @@
 import subprocess
 
+
 def get_git_repo_head_branch(repo):
     """
     A helper method to get the reference of the HEAD branch of a git remote repo.
     https://stackoverflow.com/a/41925348
     """
-    out = subprocess.check_output(["git", "ls-remote", "--symref", repo, "HEAD"]).decode()
+    out = subprocess.check_output(
+        ["git", "ls-remote", "--symref", repo, "HEAD"]
+    ).decode()
     head_branch = out.split()[1]
     return head_branch


### PR DESCRIPTION
Resolves https://github.com/CTFd/ctfcli/issues/52
- Added the category parameter for challenges that are grouped by category directories. This is needed since the git add subtree command is called from the top-level tree
- Changed git clone to use git subtree so challenges have two way communication, aka changes to the local challenge can be pushed to the main challenge and changes in the main challenge can be pulled to the local challenge
- Included `git remote add challenge_name` so users can pull and push with the less verbose command git subtree pull --prefix subtree_location challenge_name --master rather than having to use the full challenge url

Should there be print statements of the git subtree pull and push commands after the git remote print statements so users know what to look up to use it effectively?