### PR TITLE
Refactoring the ctf challenge update command to use git subtree pull to update the repos

### DIFF
--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -178,22 +178,11 @@ class Challenge(object):
             if challenge and challenge != folder:
                 continue
             if url.endswith(".git"):
-                click.echo(f"Cloning {url} to {folder}")
-                subprocess.call(["git", "init"], cwd=folder)
-                subprocess.call(["git", "remote", "add", "origin", url], cwd=folder)
-                subprocess.call(["git", "add", "-A"], cwd=folder)
-                subprocess.call(
-                    ["git", "commit", "-m", "Persist local changes (ctfcli)"],
-                    cwd=folder,
-                )
-                subprocess.call(
-                    ["git", "pull", "--allow-unrelated-histories", "origin", "master"],
-                    cwd=folder,
-                )
+                click.echo(f"Pulling latest {url} to {folder}")
+                subprocess.call(["git", "subtree", "pull", "--prefix", folder, url, "master", "--squash"])
                 subprocess.call(["git", "mergetool"], cwd=folder)
                 subprocess.call(["git", "clean", "-f"], cwd=folder)
                 subprocess.call(["git", "commit", "--no-edit"], cwd=folder)
-                shutil.rmtree(str(Path(folder) / ".git"))
             else:
                 click.echo(f"Skipping {url} - {folder}")
 


### PR DESCRIPTION
Resolves https://github.com/CTFd/ctfcli/issues/52
- Changed the clone pull strategy for updating to use the subtree pull strategy which would match the new ctf challenge add flow since it also uses git subtree