### PR TITLE
Add a configuration in .ctf/config to disable ssl verification

### DIFF
--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -63,8 +63,21 @@ def preview_config(as_string=False):
 
 def generate_session():
     config = load_config()
+
+    # Load required configuration values
     url = config["config"]["url"]
     access_token = config["config"]["access_token"]
+
+    # Handle SSL verification disabling
+    try:
+        # Get an ssl_verify config. Default to True if it doesn't exist
+        ssl_verify = config["config"].getboolean("ssl_verify", True)
+    except ValueError:
+        # If we didn't a proper boolean value we should load it as a string
+        # https://requests.kennethreitz.org/en/master/user/advanced/#ssl-cert-verification
+        ssl_verify = config["config"].get("ssl_verify")
+
     s = APISession(prefix_url=url)
+    s.verify = ssl_verify
     s.headers.update({"Authorization": f"Token {access_token}"})
     return s


### PR DESCRIPTION
* Add `ssl_verify` in the `.ctf/config` file to support SSL verification disabling
* `ssl_verify` mimics the `verify` parameter in requests in that it can be `true` or `false` or a string (specifying the trusted SSL certificates)