### PR TITLE
Fix package installation with pip3

### DIFF
--- a/ctfcli/cli/plugins.py
+++ b/ctfcli/cli/plugins.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import subprocess
 
+import click
+
 from ctfcli.utils.plugins import get_plugin_dir
 
 
@@ -11,8 +13,19 @@ class Plugins(object):
             get_plugin_dir(), os.path.basename(url).rsplit(".", maxsplit=1)[0]
         )
         subprocess.call(["git", "clone", url, local_dir])
+
+        pip = shutil.which("pip")
+        pip3 = shutil.which("pip3")
+
+        if pip is None and pip3 is None:
+            click.secho(f"Neither pip nor pip3 was found, is it in the PATH?", fg="red")
+            return
+
+        if pip is None:
+            pip = pip3
+
         subprocess.call(
-            ["pip", "install", "-r", os.path.join(local_dir, "requirements.txt")]
+            [pip, "install", "-r", os.path.join(local_dir, "requirements.txt")]
         )
 
     def uninstall(self, plugin_name):


### PR DESCRIPTION
ctfcli fails during plugin installation if there's no `pip` executable present - which might happen when just `pip3` is present on specific installation. This change makes ctfcli use pip by default and pip3 if it's the only one available - otherwise an alert will be printed 