### PR TITLE
Improve ctf init to skip git repo creation and create directories

### DIFF
--- a/ctfcli/utils/git.py
+++ b/ctfcli/utils/git.py
@@ -11,3 +11,25 @@ def get_git_repo_head_branch(repo):
     ).decode()
     head_branch = out.split()[1]
     return head_branch
+
+
+def check_if_dir_is_inside_git_repo(dir=None):
+    """
+    Checks whether a given directory is inside of a git repo.
+    """
+    try:
+        out = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--is-inside-work-tree"],
+                cwd=dir,
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+        print(out)
+        if out == "true":
+            return True
+        return False
+    except subprocess.CalledProcessError:
+        return False


### PR DESCRIPTION
* Adds a `--no-git` option to `ctf init` to skip git repo creation in event folder
* `ctf init` will not attempt to create git repos when the event folder is in a git repo already
* `ctf init <folder>` can now be used to create the event folder instead of creating the folder beforehand
* Closes #34 