### PR TITLE
Add if statement to avoid UnboundLocalError

### DIFF
--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -170,6 +170,16 @@ class Challenge(object):
                 click.secho(f"Success!", fg="green")
 
     def sync(self, challenge=None, ignore=()):
+        
+        # Sanity check to avoid UnboundLocalError: which occurs in the inner loop                                                                                                     │····················
+        # If there are no challenges installed at all in the database.                                                                                                                │····················
+        if not load_installed_challenges():                                                                                                                                           │····················
+            click.secho(
+                "There are no challenges installed, therefore there cannot be anything to sync, try install.",                                                               │····················
+                fg="red",                                                                                                                                                     │····················
+            )                                                                                                                                                                         │····················
+            return
+        
         if challenge is None:
             # Get all challenges if not specifying a challenge
             config = load_config()
@@ -190,7 +200,7 @@ class Challenge(object):
             challenge = load_challenge(path)
             click.secho(f'Loaded {challenge["name"]}', fg="yellow")
 
-            installed_challenges = load_installed_challenges()
+            installed_challenges = load_installed_challenges()              
             for c in installed_challenges:
                 if c["name"] == challenge["name"]:
                     break


### PR DESCRIPTION
When there are no challenges installed in ctfd, sync will throw an UnboundLocalError because the variable 'c' at line 209 will be unreferenced.
This adds a simple sanity check to avoid running sync at all if there are no challenges installed.