### PR TITLE
adding restart policy and name to docker run

### DIFF
--- a/ctfcli/utils/deploy.py
+++ b/ctfcli/utils/deploy.py
@@ -31,7 +31,7 @@ def ssh(challenge, host):
         [
             "ssh",
             host.netloc,
-            f"docker run -d -p{exposed_port}:{exposed_port} {image_name}",
+            f"docker run -d -p{exposed_port}:{exposed_port} --name {image_name} --restart always {image_name}",
         ]
     )
 


### PR DESCRIPTION
for whatever reason some of the programming challenges keep crashing. setting a restart policy on the docker containers will allow these challenges to restart without user intervention.

additionally, we can properly name the docker containers to the name of the challenge to make debugging/searching easier. this shouldn't cause any issues with unique names, since we'll collide on listening ports either way.