### PR TITLE
Add configurable cookies via config file

### DIFF
--- a/ctfcli/__main__.py
+++ b/ctfcli/__main__.py
@@ -1,4 +1,4 @@
-import configobj
+import configparser
 import importlib
 import os
 import subprocess
@@ -51,10 +51,10 @@ class CTFCLI(object):
         (path / ".ctf").mkdir()
 
         # Create initial .ctf/config file
-        config = configobj.ConfigObj()
+        config = configparser.ConfigParser()
         config["config"] = {"url": ctf_url, "access_token": ctf_token}
         config["challenges"] = {}
-        with (path / ".ctf" / "config").open(mode="a+b") as f:
+        with (path / ".ctf" / "config").open(mode="a+") as f:
             config.write(f)
 
         # Create a git repo in the event folder

--- a/ctfcli/__main__.py
+++ b/ctfcli/__main__.py
@@ -1,4 +1,4 @@
-import configparser
+import configobj
 import importlib
 import os
 import subprocess
@@ -51,10 +51,10 @@ class CTFCLI(object):
         (path / ".ctf").mkdir()
 
         # Create initial .ctf/config file
-        config = configparser.ConfigParser()
+        config = configobj.ConfigObj()
         config["config"] = {"url": ctf_url, "access_token": ctf_token}
         config["challenges"] = {}
-        with (path / ".ctf" / "config").open(mode="a+") as f:
+        with (path / ".ctf" / "config").open(mode="a+b") as f:
             config.write(f)
 
         # Create a git repo in the event folder

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -1,4 +1,4 @@
-import configobj
+import configparser
 import json
 import os
 
@@ -35,15 +35,25 @@ def get_project_path():
 
 def load_config():
     path = get_config_path()
-    parser = configobj.ConfigObj(path)
+    parser = configparser.ConfigParser()
 
+    # Preserve case in configparser
+    parser.optionxform = str
+
+    parser.read(path)
     return parser
 
 
 def preview_config(as_string=False):
     config = load_config()
 
-    preview = json.dumps(config, sort_keys=True, indent=4)
+    d = {}
+    for section in config.sections():
+        d[section] = {}
+        for k, v in config.items(section):
+            d[section][k] = v
+
+    preview = json.dumps(d, sort_keys=True, indent=4)
 
     if as_string is True:
         return preview
@@ -61,10 +71,7 @@ def generate_session():
     # Handle SSL verification disabling
     try:
         # Get an ssl_verify config. Default to True if it doesn't exist
-        if config["config"].get("ssl_verify"):
-            ssl_verify = config["config"].as_bool("ssl_verify")
-        else:
-            ssl_verify = True
+        ssl_verify = config["config"].getboolean("ssl_verify", True)
     except ValueError:
         # If we didn't a proper boolean value we should load it as a string
         # https://requests.kennethreitz.org/en/master/user/advanced/#ssl-cert-verification
@@ -73,6 +80,8 @@ def generate_session():
     s = APISession(prefix_url=url)
     s.verify = ssl_verify
     s.headers.update({"Authorization": f"Token {access_token}"})
-    s.cookies.update(config["config"].get("cookies", {}))
+
+    if 'cookies' in config:
+        s.cookies.update(config["cookies"])
 
     return s

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -81,7 +81,7 @@ def generate_session():
     s.verify = ssl_verify
     s.headers.update({"Authorization": f"Token {access_token}"})
 
-    if config["cookies"]:
+    if 'cookies' in config:
         s.cookies.update(config["cookies"])
 
     return s

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -81,7 +81,7 @@ def generate_session():
     s.verify = ssl_verify
     s.headers.update({"Authorization": f"Token {access_token}"})
 
-    if config["config"]["cookies"]:
+    if config["cookies"]:
         s.cookies.update(config["cookies"])
 
     return s

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -80,4 +80,8 @@ def generate_session():
     s = APISession(prefix_url=url)
     s.verify = ssl_verify
     s.headers.update({"Authorization": f"Token {access_token}"})
+
+    if config["config"]["cookies"]:
+        s.cookies.update(config["cookies"])
+
     return s

--- a/ctfcli/utils/config.py
+++ b/ctfcli/utils/config.py
@@ -81,7 +81,8 @@ def generate_session():
     s.verify = ssl_verify
     s.headers.update({"Authorization": f"Token {access_token}"})
 
-    if 'cookies' in config:
-        s.cookies.update(config["cookies"])
+    # Handle cookies section in config
+    if "cookies" in config:
+        s.cookies.update(dict(config["cookies"]))
 
     return s


### PR DESCRIPTION
For example:

```ini
[cookies]
site_password = your_password
```

Allows ctfcli to connect when a [site password](https://docs.ctfd.io/hosted/security/setting-site-password) is configured. Fixes #111 