### PR TITLE
Add timeout to cloud challenge deployment

### DIFF
--- a/ctfcli/utils/deploy.py
+++ b/ctfcli/utils/deploy.py
@@ -143,12 +143,20 @@ def cloud(challenge, host, protocol):
     service_id = service["id"]
     service = s.get(f"/api/v1/services/{service_id}", json=True).json()["data"]
 
-    while service["hostname"] is None:
+    DEPLOY_TIMEOUT = 180
+    while service["hostname"] is None and DEPLOY_TIMEOUT > 0:
         click.secho(
             "Waiting for challenge hostname", fg="yellow",
         )
         service = s.get(f"/api/v1/services/{service_id}", json=True).json()["data"]
+        DEPLOY_TIMEOUT -= 10
         time.sleep(10)
+
+    if DEPLOY_TIMEOUT == 0:
+        click.secho(
+            "Timeout waiting for challenge to deploy", fg="red",
+        )
+        return False, None, None, None
 
     # Expose port if we are using tcp
     if protocol == "tcp":


### PR DESCRIPTION
If a cloud challenge fails to deploy (eg missing EXPOSE), ctfcli will wait indefinitely. This PR adds a 3-minute timeout.

Alternatively, we could add a check for `service.status == "failed"`