### PR TITLE
add directory option to ctfcli add

### DIFF
--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -53,7 +53,7 @@ class Challenge(object):
 
         Templates().list()
 
-    def add(self, repo, yaml_path=None):
+    def add(self, repo, directory=None, yaml_path=None):
         config = load_config()
 
         if repo.endswith(".git"):
@@ -63,9 +63,11 @@ class Challenge(object):
             # Get new directory that will add the git subtree
             base_repo_path = Path(os.path.basename(repo).rsplit(".", maxsplit=1)[0])
 
+            if directory:
+                base_repo_path = directory / base_repo_path
+
             # Join targets
             challenge_path = challenge_path / base_repo_path
-            print(challenge_path)
 
             # If a custom yaml_path is specified we add it to our challenge_key
             if yaml_path:

--- a/ctfcli/utils/deploy.py
+++ b/ctfcli/utils/deploy.py
@@ -136,7 +136,7 @@ def cloud(challenge, host, protocol):
         # Could not find the service. Create it using our pushed image.
         # Deploy the image by creating service
         service = s.post(
-            "/api/v1/services", json={"name": slug, "image": location,}
+            "/api/v1/services", json={"name": slug, "image": location,},
         ).json()["data"]
 
     # Get connection details


### PR DESCRIPTION
This adds `--directory` argument to `ctfcli add` - useful for grouping challenges into separate directories like: `web/challenge1`.

Challenges can be always moved, but that breaks `ctfcli update` (and I imagine others too) - because git will fail to find a subtree that has been manually moved.