### PR TITLE
ignore state when syncing deployed challenge

### DIFF
--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -724,16 +724,7 @@ class ChallengeCommand:
                 try:
                     if existing_challenge:
                         click.secho(f"Updating challenge '{challenge_name}'", fg="blue")
-                        challenge.sync(
-                            ignore=[
-                                "flags",
-                                "topics",
-                                "tags",
-                                "files",
-                                "hints",
-                                "requirements",
-                            ]
-                        )
+                        challenge.sync(ignore=["flags", "topics", "tags", "files", "hints", "requirements", "state"])
                     else:
                         click.secho(f"Creating challenge '{challenge_name}'", fg="blue")
                         challenge.create()


### PR DESCRIPTION
When a challenge service is deployed, it will sync the challenge automatically (to include connection_info) and also possibly make a previously hidden challenge (e.g. created with --hidden or just hidden in the admin panel manually) __visible__ (because it does not define state in `challenge.yml`).

 I think it's best to always leave the state as-is with the deployment because the sync happens automatically - the user might be unaware that the challenge he or she made hidden has now been made visible.