### PR TITLE
Properly add challenge.yml for templates into the poetry built package

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -1,0 +1,7 @@
+import os
+
+def replace_symlinks():
+    os.system("""find . -type l -exec sh -c 'target=$(readlink -f "$0"); rm "$0" && cp "$target" "$0"' {} \;""")
+
+if __name__ == "__main__":
+    replace_symlinks()

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,7 +1,9 @@
 import os
 
+
 def replace_symlinks():
     os.system("""find . -type l -exec sh -c 'target=$(readlink -f "$0"); rm "$0" && cp "$target" "$0"' {} \;""")
+
 
 if __name__ == "__main__":
     replace_symlinks()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,11 @@ readme = "README.md"
 [tool.poetry.scripts]
 ctf = "ctfcli.__main__:main"
 
+[tool.poetry.build]
+# I don't understand why poetry doesn't seem to be following symlinks. 
+# This script resolves the symlinks in the templates to the example challenge spec
+script = "preprocess.py"
+
 [tool.poetry.dependencies]
 python = "^3.8"
 python-frontmatter = "^1.0.0"


### PR DESCRIPTION
Have poetry run a preprocess script which replaces the challenge.yml symlinks with the actual file contents

I don't really understand why this is happening since other people seem to report that Poetry is resolving symlinks for them and it seems like the expected behavior is to resolve the symlinks. 

https://github.com/python-poetry/poetry/issues/1998
https://github.com/pypa/pip/issues/3500

Closes #137 