### PR TITLE
Mark 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# 0.1.1 / 2023-12-11
+
+### Added
+
+- Added `ctf challenge mirror` command to pull changes from the remote CTFd instance into the local project
+
+### Fixed
+
+- Properly include challenge.yml when generating a challenge from a template
+
+### Changed
+
+- No longer require a ctfcli project to run all `ctf challenge` (e.g. `new`, `format`, `lint`)
+
 # 0.1.0 / 2023-10-03
 
 ### Added

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __name__ = "ctfcli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ctfcli"
-version = "0.1.0"
+version = "0.1.1"
 description = "ctfcli is a tool to manage Capture The Flag events and challenges"
 authors = ["Kevin Chung <kchung@ctfd.io>", "Miłosz Skaza <milosz.skaza@ctfd.io>"]
 readme = "README.md"


### PR DESCRIPTION
# 0.1.1 / 2023-12-11

### Added

- Added `ctf challenge mirror` command to pull changes from the remote CTFd instance into the local project

### Fixed

- Properly include challenge.yml when generating a challenge from a template

### Changed

- No longer require a ctfcli project to run all `ctf challenge` (e.g. `new`, `format`, `lint`)