### PR TITLE
Support remote images

### DIFF
--- a/ctfcli/core/image.py
+++ b/ctfcli/core/image.py
@@ -13,7 +13,7 @@ class Image:
 
         # if the image is a remote image (eg. ghcr.io/.../...), extract the basename
         self.basename = name
-        if "/" in self.name or "" in self.name:
+        if "/" in self.name or ":" in self.name:
             self.basename = self.name.split(":")[0].split("/")[-1]
 
         self.built = True

--- a/tests/core/deployment/test_cloud_deployment.py
+++ b/tests/core/deployment/test_cloud_deployment.py
@@ -83,6 +83,8 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
+        mock_image.built = False
         mock_image.build.return_value = None
 
         mock_api: MagicMock = mock_api_constructor.return_value
@@ -134,6 +136,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = None
 
@@ -201,6 +204,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
 
         mock_api: MagicMock = mock_api_constructor.return_value
@@ -282,6 +286,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
 
         mock_api: MagicMock = mock_api_constructor.return_value
@@ -365,6 +370,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = "registry.ctfd.io/example-project/test-challenge"
 
@@ -495,6 +501,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = "registry.ctfd.io/example-project/test-challenge"
 
@@ -637,6 +644,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = "registry.ctfd.io/example-project/test-challenge"
 
@@ -830,6 +838,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = "registry.ctfd.io/example-project/test-challenge"
 
@@ -1019,6 +1028,7 @@ class TestCloudDeployment(unittest.TestCase):
 
         mock_image = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = "registry.ctfd.io/example-project/test-challenge"
 

--- a/tests/core/deployment/test_registry_deployment.py
+++ b/tests/core/deployment/test_registry_deployment.py
@@ -30,6 +30,7 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = "registry.example.com/example-project/test-challenge"
 
@@ -79,6 +80,7 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
 
         handler = RegistryDeploymentHandler(challenge, host="registry://registry.example.com/example-project")
@@ -104,6 +106,7 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
 
         mock_config_constructor.return_value = {"registry": {"username": "test"}}
@@ -133,6 +136,7 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
 
         mock_config_constructor.return_value = {"registry": {"username": "test", "password": "test"}}
@@ -164,6 +168,8 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
+        mock_image.built = False
         mock_image.build.return_value = None
 
         mock_config_constructor.return_value = {"registry": {"username": "test", "password": "test"}}
@@ -192,6 +198,7 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = None
 
@@ -224,6 +231,7 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = "registry.example.com/example-project/test-challenge"
 
@@ -257,6 +265,7 @@ class TestRegistryDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.push.return_value = None
 

--- a/tests/core/deployment/test_ssh_deployment.py
+++ b/tests/core/deployment/test_ssh_deployment.py
@@ -33,6 +33,7 @@ class TestSSHDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.export.return_value = "/tmp/test/test-challenge.tar"
         mock_image.get_exposed_port.return_value = 80
@@ -105,6 +106,7 @@ class TestSSHDeployment(unittest.TestCase):
         challenge = Challenge(self.challenge_path)
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.built = False
         mock_image.build.return_value = None
 
         handler = SSHDeploymentHandler(challenge, host="ssh://root@127.0.0.1")
@@ -128,6 +130,7 @@ class TestSSHDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.export.return_value = None
 
@@ -152,6 +155,7 @@ class TestSSHDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.export.return_value = "/tmp/test/test-challenge.tar"
         mock_image.get_exposed_port.return_value = None
@@ -181,6 +185,7 @@ class TestSSHDeployment(unittest.TestCase):
 
         mock_image: MagicMock = mock_image_constructor.return_value
         mock_image.name = "test-challenge"
+        mock_image.basename = "test-challenge"
         mock_image.build.return_value = "test-challenge"
         mock_image.export.return_value = "/tmp/test/test-challenge.tar"
         mock_image.get_exposed_port.return_value = 80

--- a/tests/core/test_challenge.py
+++ b/tests/core/test_challenge.py
@@ -106,6 +106,7 @@ class TestLocalChallengeLoading(unittest.TestCase):
         challenge = Challenge(challenge_path, {"image": "test-challenge:latest"})
         self.assertIsNone(challenge.image)
 
+
 class TestRemoteChallengeLoading(unittest.TestCase):
     @mock.patch("ctfcli.core.challenge.API")
     def test_load_installed_challenge(self, mock_api: MagicMock):

--- a/tests/core/test_challenge.py
+++ b/tests/core/test_challenge.py
@@ -72,6 +72,39 @@ class TestLocalChallengeLoading(unittest.TestCase):
 
         self.assertIsNone(challenge.image)
 
+    def test_recognizes_registry_images(self):
+        challenge_path = BASE_DIR / "fixtures" / "challenges" / "test-challenge-minimal" / "challenge.yml"
+        challenge = Challenge(challenge_path, {"image": "ghcr.io/ctfcli/test-challenge:latest"})
+
+        self.assertIsInstance(challenge.image, Image)
+        self.assertEqual(challenge.image.name, "ghcr.io/ctfcli/test-challenge:latest")
+        self.assertEqual(challenge.image.basename, "test-challenge")
+        self.assertTrue(challenge.image.built)
+
+    def test_recognizes_library_images(self):
+        challenge_path = BASE_DIR / "fixtures" / "challenges" / "test-challenge-minimal" / "challenge.yml"
+        challenge = Challenge(challenge_path, {"image": "library/test-challenge:latest"})
+
+        self.assertIsInstance(challenge.image, Image)
+        self.assertEqual(challenge.image.name, "docker.io/library/test-challenge:latest")
+        self.assertEqual(challenge.image.basename, "test-challenge")
+        self.assertTrue(challenge.image.built)
+
+    @mock.patch("ctfcli.core.challenge.subprocess.call")
+    def test_recognizes_local_prebuilt_images(self, mock_call: MagicMock):
+        mock_call.return_value = 0
+        challenge_path = BASE_DIR / "fixtures" / "challenges" / "test-challenge-minimal" / "challenge.yml"
+        challenge = Challenge(challenge_path, {"image": "test-challenge:latest"})
+
+        self.assertIsInstance(challenge.image, Image)
+        self.assertEqual(challenge.image.name, "test-challenge:latest")
+        self.assertEqual(challenge.image.basename, "test-challenge")
+        self.assertTrue(challenge.image.built)
+
+        mock_call.return_value = 1
+        challenge_path = BASE_DIR / "fixtures" / "challenges" / "test-challenge-minimal" / "challenge.yml"
+        challenge = Challenge(challenge_path, {"image": "test-challenge:latest"})
+        self.assertIsNone(challenge.image)
 
 class TestRemoteChallengeLoading(unittest.TestCase):
     @mock.patch("ctfcli.core.challenge.API")

--- a/tests/core/test_image.py
+++ b/tests/core/test_image.py
@@ -17,6 +17,26 @@ class TestImage(unittest.TestCase):
         self.assertEqual(image.build_path, build_path)
         self.assertFalse(image.built)
 
+    def test_extracts_correct_basename(self):
+        image_names = [
+            "test-challenge",
+            "test-challenge:latest",
+            "test-challenge:1.0.0",
+            "registry.ctfd.io/example-project/test-challenge",
+            "registry.ctfd.io/example-project/test-challenge:latest",
+            "registry.ctfd.io/example-project/test-challenge:1.0.0",
+            "ghcr.io/example-org/test-challenge",
+            "ghcr.io/example-org/test-challenge:latest",
+            "ghcr.io/example-org/test-challenge:1.0.0",
+            "library/test-challenge",
+            "library/test-challenge:latest",
+            "library/test-challenge:1.0.0",
+        ]
+
+        for name in image_names:
+            image = Image(name)
+            self.assertEqual(image.basename, "test-challenge")
+
     def test_accepts_path_as_string_and_pathlike(self):
         build_path = BASE_DIR / "fixtures" / "challenges" / "test-challenge-dockerfile"
         image = Image("test-challenge", build_path)
@@ -289,3 +309,22 @@ class TestImage(unittest.TestCase):
                 )
             ]
         )
+
+    @mock.patch("ctfcli.core.image.subprocess.call")
+    def test_pull(self, mock_call: MagicMock):
+        image_names = [
+            "test-challenge",
+            "registry.ctfd.io/example-project/test-challenge",
+            "ghcr.io/example-org/test-challenge",
+            "library/test-challenge",
+            "test-challenge:latest",
+            "registry.ctfd.io/example-project/test-challenge:latest",
+            "ghcr.io/example-org/test-challenge:latest",
+            "library/test-challenge:latest",
+        ]
+
+        for image_name in image_names:
+            image = Image(image_name)
+            image.pull()
+            self.assertEqual(image_name, image.name)
+            mock_call.assert_called_with(["docker", "pull", image_name])


### PR DESCRIPTION
This adds support for using registry images in challenge.yml. 

Right now it's not possible to define a prebuilt image to challenge.yml e.g.:

```yml
image: ghcr.io/my-org/my-challenge:latest
```