### PR TITLE
Support alternate Buildkit drivers

### DIFF
--- a/ctfcli/core/image.py
+++ b/ctfcli/core/image.py
@@ -24,7 +24,9 @@ class Image:
             self.built = False
 
     def build(self) -> Optional[str]:
-        docker_build = subprocess.call(["docker", "build", "-t", self.name, "."], cwd=self.build_path.absolute())
+        docker_build = subprocess.call(
+            ["docker", "build", "--load", "-t", self.name, "."], cwd=self.build_path.absolute()
+        )
         if docker_build != 0:
             return
 

--- a/tests/core/test_image.py
+++ b/tests/core/test_image.py
@@ -56,7 +56,9 @@ class TestImage(unittest.TestCase):
 
         self.assertTrue(image.built)
         self.assertEqual(image_name, "test-challenge")
-        mock_call.assert_called_once_with(["docker", "build", "-t", "test-challenge", "."], cwd=build_path.absolute())
+        mock_call.assert_called_once_with(
+            ["docker", "build", "--load", "-t", "test-challenge", "."], cwd=build_path.absolute()
+        )
 
     @mock.patch("ctfcli.core.image.subprocess.call", return_value=1)
     def test_build_returns_none_if_failed(self, mock_call: MagicMock):
@@ -68,7 +70,9 @@ class TestImage(unittest.TestCase):
 
         self.assertFalse(image.built)
         self.assertIsNone(image_name)
-        mock_call.assert_called_once_with(["docker", "build", "-t", "test-challenge", "."], cwd=build_path.absolute())
+        mock_call.assert_called_once_with(
+            ["docker", "build", "--load", "-t", "test-challenge", "."], cwd=build_path.absolute()
+        )
 
     @mock.patch("ctfcli.core.image.subprocess.call", return_value=0)
     def test_push_built_image(self, mock_call: MagicMock):
@@ -150,7 +154,7 @@ class TestImage(unittest.TestCase):
         mock_call.assert_has_calls(
             [
                 call(
-                    ["docker", "build", "-t", "test-challenge", "."],
+                    ["docker", "build", "--load", "-t", "test-challenge", "."],
                     cwd=build_path.absolute(),
                 ),
                 call(
@@ -224,7 +228,7 @@ class TestImage(unittest.TestCase):
         mock_call.assert_has_calls(
             [
                 call(
-                    ["docker", "build", "-t", "test-challenge", "."],
+                    ["docker", "build", "--load", "-t", "test-challenge", "."],
                     cwd=build_path.absolute(),
                 ),
                 call(


### PR DESCRIPTION
Add [--load](https://docs.docker.com/reference/cli/docker/buildx/build/#load) to explicitly output Docker builds to local images, allowing drivers that don't have a default output type (ie everything except `docker`). Fixes #147

Is it worth adding some way to pass custom arguments too? --cache-from and [--cache-to](https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to) can significantly improve performance in CI scenarios.