### PR TITLE
add support for git subrepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,14 @@ The specification format has already been tested and used with CTFd in productio
 `ctfcli` plugins are essentially additions to the command line interface via dynamic class modifications. See the [plugin documentation page](docs/plugins.md) for a simple example.
 
 *`ctfcli` is an alpha project! The plugin interface is likely to change!*
+
+# Sub-Repos as alternative to Sub-Trees
+
+`ctfcli` manages git-based challenges by using the built-in git `subtree` mechanism. While it works most of the time, it's been proven to have disadvantages and tends to create problems and merge conflicts.  
+
+As an alternative, we're currently experimenting with the git [`git subrepo`](https://github.com/ingydotnet/git-subrepo) extension. 
+This functionality can be enabled by adding a `use_subrepo = True` property to the `[config]` section inside a ctfcli project config.
+
+Subrepo has to be installed separately, and is not backwards compatible with the default `subtree`. 
+Once challenges have been added by using either method, they will not work properly if you change it, and you will have to add the challenges again.
+

--- a/ctfcli/utils/git.py
+++ b/ctfcli/utils/git.py
@@ -3,6 +3,13 @@ from os import PathLike
 from typing import Optional, Union
 
 
+def check_if_git_subrepo_is_installed() -> bool:
+    output = subprocess.run(["git", "subrepo"], capture_output=True, text=True)
+    if "git: 'subrepo' is not a git command" in output.stderr:
+        return False
+    return True
+
+
 def get_git_repo_head_branch(repo: str) -> Optional[str]:
     """
     A helper method to get the reference of the HEAD branch of a git remote repo.


### PR DESCRIPTION
Add support for using git subrepo instead of subtree to manage git-based challenges.

This seems to work well from preliminary testing, reducing the number of conflicts when pushing and pulling, and also making them easier to abort / reset.