### PR TITLE
Add Challenge.clone staticmethod to clone challenges from remote

### DIFF
--- a/ctfcli/templates/blank/empty/cookiecutter.json
+++ b/ctfcli/templates/blank/empty/cookiecutter.json
@@ -1,0 +1,4 @@
+{
+    "name": "challenge",
+	"dirname": "challenge"
+}

--- a/ctfcli/templates/blank/empty/{{cookiecutter.dirname}}/challenge.yml
+++ b/ctfcli/templates/blank/empty/{{cookiecutter.dirname}}/challenge.yml
@@ -1,0 +1,1 @@
+name: "{{cookiecutter.name}}"


### PR DESCRIPTION
* Adds `--create` to `ctf challenge mirror` to create local copies of remote challenges that do not exist locally
* Adds the `blank/empty` challenge template to support cloning to an unknown directory and challenge name
* Patch issue where the `Challenge._validate_files()` would error on a `challenge.yml` file without the files section defined
* Closes #141. Thanks @TPGamesNL!