### PR TITLE
Mark 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+# 0.1.3 / 2024-08-20
+
+### Added
+
+- Added support for `git subrepo` instead of only `git subtree`
+- Added the `--create` switch to `ctf challenge mirror` to create local copies of challenges that exist on a remote CTFd instance
+
+### Fixed
+
+- `ctf challenge {push, pull}` will now push / pull all challenges instead of the challenge in the current working directory.
+
+### Changed
+
+- Use `--load` switch as part of docker build to support alternate build drivers
+
 # 0.1.2 / 2023-02-26
 
 ### Added

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __name__ = "ctfcli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ctfcli"
-version = "0.1.2"
+version = "0.1.3"
 description = "ctfcli is a tool to manage Capture The Flag events and challenges"
 authors = ["Kevin Chung <kchung@ctfd.io>", "Miłosz Skaza <milosz.skaza@ctfd.io>"]
 readme = "README.md"


### PR DESCRIPTION
# 0.1.3 / 2024-08-20

### Added

- Added support for `git subrepo` instead of only `git subtree`
- Added the `--create` switch to `ctf challenge mirror` to create local copies of challenges that exist on a remote CTFd instance

### Fixed

- `ctf challenge {push, pull}` will now push / pull all challenges instead of the challenge in the current working directory.

### Changed

- Use `--load` switch as part of docker build to support alternate build drivers