### PR TITLE
Mark 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@
 - Fix issue with managing challenges with an empty files section
 - Fix issue where images could not be deployed due to being named incorrectly
 
-### Changed
-
 # 0.1.3 / 2024-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+# 0.1.4 / 2025-04-29
+
+### Added
+
+- Added support for `ctf instance` with the `ctf instance config` command which can be used to `get` and `set` configuration on CTFd
+- Added `ctf media add`, `ctf media rm`, `ctf media url`
+  - Allows ctfcli repos to manage files locally and reference the actual server URLs of media files in Pages
+  - Adds concept of replacing placeholders like `{{ media/ctfd.png }}` with the actual URL on the server
+- Added the `attribution` field to challenge.yml
+- Added the `next` field to challenge.yml
+- Added ability to anoymize challenges while specifying prerequisites
+- Added specifying CTFd instance URL and access token via envvars: `CTFCLI_URL`, `CTFCLI_ACCESS_TOKEN`
+
+### Fixed
+
+- Fix issue with managing challenges with an empty files section
+- Fix issue where images could not be deployed due to being named incorrectly
+
+### Changed
+
 # 0.1.3 / 2024-08-20
 
 ### Added

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __name__ = "ctfcli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ctfcli"
-version = "0.1.3"
+version = "0.1.4"
 description = "ctfcli is a tool to manage Capture The Flag events and challenges"
 authors = ["Kevin Chung <kchung@ctfd.io>", "Miłosz Skaza <milosz.skaza@ctfd.io>"]
 readme = "README.md"


### PR DESCRIPTION
# 0.1.4 / 2025-04-29

### Added

- Added support for `ctf instance` with the `ctf instance config` command which can be used to `get` and `set` configuration on CTFd
- Added `ctf media add`, `ctf media rm`, `ctf media url`
  - Allows ctfcli repos to manage files locally and reference the actual server URLs of media files in Pages
  - Adds concept of replacing placeholders like `{{ media/ctfd.png }}` with the actual URL on the server
- Added the `attribution` field to challenge.yml
- Added the `next` field to challenge.yml
- Added ability to anoymize challenges while specifying prerequisites
- Added specifying CTFd instance URL and access token via envvars: `CTFCLI_URL`, `CTFCLI_ACCESS_TOKEN`

### Fixed

- Fix issue with managing challenges with an empty files section
- Fix issue where images could not be deployed due to being named incorrectly