### PR TITLE
Sync ignore checksum

### DIFF
--- a/ctfcli/core/challenge.py
+++ b/ctfcli/core/challenge.py
@@ -736,7 +736,7 @@ class Challenge(dict):
                         ) as lf:
                             local_file_sha1sum = hash_file(lf)
 
-                        if local_file_sha1sum == remote_file_sha1sum:
+                        if not "checksum" in ignore and local_file_sha1sum == remote_file_sha1sum:
                             continue
 
                     # if sha1sums are not present, or the hashes are different, re-upload the file


### PR DESCRIPTION
Option to ignore file checksum in case physical files gets removed while file cache still exists in database