### PR TITLE
Mark 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 0.1.5 / 2025-09-04
+
+### Added
+
+- Support for hint titles
+- Support `logic` key for challenges
+
+### Fixed
+
+- Fix issue with resolving relative challenge paths during install
+
 # 0.1.4 / 2025-04-29
 
 ### Added

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __name__ = "ctfcli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ctfcli"
-version = "0.1.4"
+version = "0.1.5"
 description = "ctfcli is a tool to manage Capture The Flag events and challenges"
 authors = ["Kevin Chung <kchung@ctfd.io>", "Miłosz Skaza <milosz.skaza@ctfd.io>"]
 readme = "README.md"


### PR DESCRIPTION
# 0.1.5 / 2025-09-04

### Added

- Support for hint titles
- Support `logic` key for challenges

### Fixed

- Fix issue with resolving relative challenge paths during install