### PR TITLE
Fix return value for sync verification

### DIFF
--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -1050,7 +1050,7 @@ class ChallengeCommand:
             if len(challenges_out_of_sync) > 1:
                 return 2
 
-            return 1
+            return 0
 
         click.secho("Verification failed for:", fg="red")
         for challenge_instance in failed_verifications:

--- a/ctfcli/cli/challenges.py
+++ b/ctfcli/cli/challenges.py
@@ -1047,7 +1047,7 @@ class ChallengeCommand:
                 for challenge_instance in challenges_out_of_sync:
                     click.echo(f" - {challenge_instance}")
 
-            if len(challenges_out_of_sync) > 1:
+            if len(challenges_out_of_sync) >= 1:
                 return 2
 
             return 0


### PR DESCRIPTION
The other operations return 0 on success. Verify returned 1 on both failure and success.