### PR TITLE
Mark 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add support for hint requirements through hint keys
+  - Hints in challenge.yml can now specify a `key` and list other hints' keys under `requirements` to gate them behind those hints
 - Add repo integrations to create challenge repos with sync integrations during `ctf init`, including `ctf init --github --gitlab`
 - Add `--force` to `ctf pages`
 
@@ -12,8 +13,6 @@
 
 - Fix return value for sync verification to properly check for failed challenge verification counts
 - Stream POST requests using a multipart encoder to handle large file uploads without reading the entire file into memory
-
-### Changed
 
 # 0.1.7 / 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+# 0.1.8 / 2026-07-14
+
+### Added
+
+- Add support for hint requirements through hint keys
+- Add repo integrations to create challenge repos with sync integrations during `ctf init`, including `ctf init --github --gitlab`
+- Add `--force` to `ctf pages`
+
+### Fixed
+
+- Fix return value for sync verification to properly check for failed challenge verification counts
+- Stream POST requests using a multipart encoder to handle large file uploads without reading the entire file into memory
+
+### Changed
+
 # 0.1.7 / 2026-02-26
 
 ### Added

--- a/ctfcli/__init__.py
+++ b/ctfcli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 __name__ = "ctfcli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctfcli"
-version = "0.1.7"
+version = "0.1.8"
 description = "ctfcli is a tool to manage Capture The Flag events and challenges"
 authors = [
     { name = "Kevin Chung", email = "kchung@ctfd.io" },


### PR DESCRIPTION
# 0.1.8 / 2026-07-14

### Added

- Add support for hint requirements through hint keys
  - Hints in challenge.yml can now specify a `key` and list other hints' keys under `requirements` to gate them behind those hints
- Add repo integrations to create challenge repos with sync integrations during `ctf init`, including `ctf init --github --gitlab`
- Add `--force` to `ctf pages`

### Fixed

- Fix return value for sync verification to properly check for failed challenge verification counts
- Stream POST requests using a multipart encoder to handle large file uploads without reading the entire file into memory